### PR TITLE
Update hardware.md

### DIFF
--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -3,6 +3,7 @@
 OpenRecall has been tested on a variety of hardware configurations. The following list is not exhaustive, but it should give you an idea of the hardware that OpenRecall has been tested on:
 
 - Apple MacBook Pro (2022) with M1 Pro and M1 Max chips
+- Apple MacBook Air (2022) with M2 chip
 - Dell XPS 13 (2022) with Intel Core i7-12700H
 - Lenovo ThinkPad X1 Carbon (2022) with Intel Core i7-12700H
 


### PR DESCRIPTION
Added M2 MacBook Air to known list of hardware where openrecall has proven to run successfully