### PR TITLE
Enable pytest in vscode

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Open your browser to:
 ## Contribute
 
 As an open-source project, we welcome contributions from the community. If you'd like to help improve OpenRecall, please submit a pull request or open an issue on our GitHub repository.
+For [testing](docs/testing.md) we use pytest.
 
 ## Contact the maintainers
 mail@datatalk.be

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,15 @@
+# Testing
+
+A set of tests is provided in the tests directory. To setup testing with VSCode, press 
+* Ctrl + Shift + P, 
+* Python: Configure Tests
+* Select "PyTest" as testenvironment
+* Select tests as test directory
+VS Code should show all tests in the test tab
+
+To run the tests from command line execute
+
+```
+python3 -m pytest
+```
+

--- a/openrecall/config.py
+++ b/openrecall/config.py
@@ -1,3 +1,16 @@
+"""Initial configuration of the application. Read the cli parameters, check & set path to 
+screenshots and database
+
+Usage:
+import openrecall.config
+
+Returns:
+    parser: parser object containing the CLI parameters
+    appdata_folder: path to appdata folder
+    screenshots_path: path to screenshots folder
+    db_path: path to sqlite database recall.db
+    get_appdata_folder: Function to get appdata folder
+"""
 import os
 import sys
 import argparse
@@ -19,10 +32,22 @@ parser.add_argument(
     default=False,
 )
 
-args = parser.parse_args()
+# do not exit on unknown parametes to enables pytest.
+# unknown parameters are never used.
+# Consider invoking these functions from the main application
+args, unknown = parser.parse_known_args()
 
 
 def get_appdata_folder(app_name="openrecall"):
+    """
+    This function returns the path to the appdata folder dependent on the opersting system.
+    Create directory if not exists.
+
+    Args:
+        app_name (str, optional): name of the directory for this application. 
+        Defaults to "openrecall".
+    """
+
     if sys.platform == "win32":
         appdata = os.getenv("APPDATA")
         if not appdata:
@@ -38,11 +63,12 @@ def get_appdata_folder(app_name="openrecall"):
         os.makedirs(path)
     return path
 
+
 if args.storage_path:
     appdata_folder = args.storage_path
     screenshots_path = os.path.join(appdata_folder, "screenshots")
     db_path = os.path.join(appdata_folder, "recall.db")
-else:   
+else:
     appdata_folder = get_appdata_folder()
     db_path = os.path.join(appdata_folder, "recall.db")
     screenshots_path = os.path.join(appdata_folder, "screenshots")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,6 @@
 import pytest
 from unittest import mock
-from openrecall.config import get_appdata_folder
+from openrecall.config import get_appdata_folder, screenshots_path, db_path
 
 def test_get_appdata_folder_windows(tmp_path):
     with mock.patch('sys.platform', 'win32'):
@@ -28,3 +28,12 @@ def test_get_appdata_folder_linux(tmp_path):
             expected_path = tmp_path / '.local' / 'share' / 'openrecall'
             assert get_appdata_folder() == str(expected_path)
             assert expected_path.exists()
+
+#Test if database exists
+def test_if_database_exists (tmp_path):
+    assert (tmp_path / db_path).exists()
+#Test if screenshot file exists
+
+def test_if_screenshot_path_exists (tmp_path):
+    assert (tmp_path / screenshots_path).exists()
+

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,0 +1,18 @@
+import sqlite3
+from openrecall.config import db_path
+
+#Test database structure
+def test_db_structure (tmp_path):
+        with sqlite3.connect(db_path) as conn:
+            c = conn.cursor()
+            c.execute(
+                """PRAGMA TABLE_INFO (entries)"""
+            )
+            columns = c.fetchall()
+            assert (columns==[(0, 'id', 'INTEGER', 0, None, 1)
+                              , (1, 'app', 'TEXT', 0, None, 0)
+                              , (2, 'title', 'TEXT', 0, None, 0)
+                              , (3, 'text', 'TEXT', 0, None, 0)
+                              , (4, 'timestamp', 'INTEGER', 0, None, 0)
+                              , (5, 'embedding', 'BLOB', 0, None, 0)
+                              ])

--- a/tests/test_nlp.py
+++ b/tests/test_nlp.py
@@ -28,6 +28,8 @@ def test_cosine_similarity_arbitrary_vectors():
     expected_similarity = np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b))
     assert cosine_similarity(a, b) == pytest.approx(expected_similarity)
 
+# Test expects N/A after divison by zero, filter warning
+@pytest.mark.filterwarnings("ignore:invalid value encountered")
 def test_cosine_similarity_zero_vector():
     a = np.array([0, 0, 0])
     b = np.array([1, 0, 0])


### PR DESCRIPTION
Setup testing for vscode.
fix issue with openrecall.config module parameter handling.
update tests to be without warning
add some comments
add some hints in the md files
add tests for screenshot path, db path and database structure