### PR TITLE
Date and Time Range Filter for Screenshot Search

### DIFF
--- a/openrecall/database.py
+++ b/openrecall/database.py
@@ -48,3 +48,13 @@ def insert_entry(
             conn.commit()
     except sqlite3.OperationalError as e:
         print("Error inserting entry:", e)
+
+
+def get_entries_by_time_range(start_time: int, end_time: int) -> List[Entry]:
+    with sqlite3.connect(db_path) as conn:
+        c = conn.cursor()
+        results = c.execute(
+            "SELECT * FROM entries WHERE timestamp BETWEEN ? AND ? ORDER BY timestamp DESC",
+            (start_time, end_time),
+        ).fetchall()
+        return [Entry(*result) for result in results]


### PR DESCRIPTION
Add Date and Time Range Filter for Screenshot Search

## Summary

This pull request adds a date and time range filter to the screenshot search functionality in the OpenRecall application. Users can now specify a date and time range to filter the screenshots displayed in the search results.

## Changes

- Updated the `search` route in `app.py` to accept `start_time` and `end_time` parameters.
- Added a form in the search page template to allow users to input a date and time range.
- Implemented a new function `get_entries_by_time_range` in `database.py` to retrieve entries based on the specified time range.

## Motivation

This feature allows users to narrow down their search results to a specific time frame, making it easier to find relevant screenshots. It's particularly useful when users have a large number of screenshots and want to focus on a specific period.

## Testing

- Manually tested the date and time range filter by entering various ranges and verifying that the correct screenshots are displayed.
- Ensured that the search functionality works as expected with and without the date and time range filter.

## Screenshots

![e841b47f-d680-49ab-a27b-67aec5f70682](https://github.com/user-attachments/assets/c9c5ec5d-6089-4e65-8bac-4a2521a83045)
