### PR TITLE
Ran test files on M3 Max

### DIFF
--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -3,6 +3,7 @@
 OpenRecall has been tested on a variety of hardware configurations. The following list is not exhaustive, but it should give you an idea of the hardware that OpenRecall has been tested on:
 
 - Apple MacBook Pro (2022) with M1 Pro and M1 Max chips
+- Apple MacBook Pro (2023) with M3 Max chip
 - Dell XPS 13 (2022) with Intel Core i7-12700H
 - Lenovo ThinkPad X1 Carbon (2022) with Intel Core i7-12700H
 


### PR DESCRIPTION
### Description
Ran the test on my machine, it's a 2023 MacBook Pro M3 Max. Results below.


<img width="1046" alt="image" src="https://github.com/user-attachments/assets/021cf3a9-67f0-4794-9837-c5a2cc6ac62d">
