### PR TITLE
Screenshot bugfixes

### DIFF
--- a/openrecall/screenshot.py
+++ b/openrecall/screenshot.py
@@ -192,7 +192,7 @@ def record_screenshots_thread():
                     format="webp",
                     lossless=True,
                 )
-                text: str = extract_text_from_image(last_screenshot)
+                text: str = extract_text_from_image(screenshot)
                 # Only proceed if OCR actually extracts text
                 if text.strip():
                     embedding: np.ndarray = get_embedding(text)


### PR DESCRIPTION
There were a couple of issues preventing screenshots from working. Related to incorrect variable names and parameters.

For line 202, the timestamp is the filename, and there is no parameter for a separate file name.