### PR TITLE
Add multi-monitor support with persistent configuration

### DIFF
--- a/openrecall/app.py
+++ b/openrecall/app.py
@@ -5,7 +5,10 @@ from flask import Flask, render_template_string, request, send_from_directory
 from jinja2 import BaseLoader
 
 from openrecall.config import appdata_folder, screenshots_path
-from openrecall.database import create_db, get_all_entries, get_timestamps
+from openrecall.database import (
+    create_db, get_all_entries, get_timestamps,
+    get_all_monitors, update_monitor_enabled, update_monitor_name
+)
 from openrecall.nlp import cosine_similarity, get_embedding
 from openrecall.screenshot import record_screenshots_thread
 from openrecall.utils import human_readable_time, timestamp_to_human_readable
@@ -50,14 +53,28 @@ base_template = """
   </style>
 </head>
 <body>
-<nav class="navbar navbar-light bg-light">
+<nav class="navbar navbar-expand-lg navbar-light bg-light">
   <div class="container">
-    <form class="form-inline my-2 my-lg-0 w-100 d-flex" action="/search" method="get">
-      <input class="form-control flex-grow-1 mr-sm-2" type="search" name="q" placeholder="Search" aria-label="Search">
-      <button class="btn btn-outline-secondary my-2 my-sm-0" type="submit">
-        <i class="bi bi-search"></i>
-      </button>
-    </form>
+    <a class="navbar-brand" href="/">OpenRecall</a>
+    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNav">
+      <ul class="navbar-nav mr-auto">
+        <li class="nav-item">
+          <a class="nav-link" href="/">Timeline</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="/monitors">Monitors</a>
+        </li>
+      </ul>
+      <form class="form-inline my-2 my-lg-0" action="/search" method="get">
+        <input class="form-control mr-sm-2" type="search" name="q" placeholder="Search" aria-label="Search">
+        <button class="btn btn-outline-secondary my-2 my-sm-0" type="submit">
+          <i class="bi bi-search"></i>
+        </button>
+      </form>
+    </div>
   </div>
 </nav>
 {% block content %}
@@ -68,7 +85,7 @@ base_template = """
   <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.5.3/dist/umd/popper.min.js"></script>
   <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
-  
+
 </body>
 </html>
 """
@@ -86,8 +103,18 @@ app.jinja_env.loader = StringLoader()
 
 @app.route("/")
 def timeline():
-    # connect to db
-    timestamps = get_timestamps()
+    # Get all entries and group by timestamp
+    entries = get_all_entries()
+
+    # Group entries by timestamp (descending order)
+    from collections import defaultdict
+    timestamp_groups = defaultdict(list)
+    for entry in entries:
+        timestamp_groups[entry.timestamp].append(entry)
+
+    # Get unique timestamps in descending order
+    timestamps = sorted(timestamp_groups.keys(), reverse=True)
+
     return render_template_string(
         """
 {% extends "base_template" %}
@@ -98,27 +125,57 @@ def timeline():
       <input type="range" class="slider custom-range" id="discreteSlider" min="0" max="{{timestamps|length - 1}}" step="1" value="{{timestamps|length - 1}}">
       <div class="slider-value" id="sliderValue">{{timestamps[0] | timestamp_to_human_readable }}</div>
     </div>
-    <div class="image-container">
-      <img id="timestampImage" src="/static/{{timestamps[0]}}.webp" alt="Image for timestamp">
+    <div class="image-container" id="imageContainer">
+      <!-- Images will be inserted here by JavaScript -->
     </div>
   </div>
   <script>
+    const timestampGroups = {{ timestamp_groups|tojson }};
     const timestamps = {{ timestamps|tojson }};
     const slider = document.getElementById('discreteSlider');
     const sliderValue = document.getElementById('sliderValue');
-    const timestampImage = document.getElementById('timestampImage');
+    const imageContainer = document.getElementById('imageContainer');
+
+    function updateImages(timestamp) {
+      const entries = timestampGroups[timestamp];
+      imageContainer.innerHTML = '';
+
+      if (entries && entries.length > 0) {
+        entries.forEach(entry => {
+          const wrapper = document.createElement('div');
+          wrapper.style.marginBottom = '20px';
+
+          const label = document.createElement('div');
+          label.className = 'text-muted mb-2';
+          label.textContent = entry.monitor_name || 'Monitor ' + entry.monitor_id;
+
+          const img = document.createElement('img');
+          img.src = `/static/${timestamp}_${entry.monitor_id}.webp`;
+          img.alt = `Screenshot from ${entry.monitor_name}`;
+          img.style.maxWidth = '100%';
+          img.style.height = 'auto';
+          img.style.border = '1px solid #ddd';
+          img.style.borderRadius = '4px';
+          img.style.padding = '5px';
+
+          wrapper.appendChild(label);
+          wrapper.appendChild(img);
+          imageContainer.appendChild(wrapper);
+        });
+      }
+    }
 
     slider.addEventListener('input', function() {
       const reversedIndex = timestamps.length - 1 - slider.value;
       const timestamp = timestamps[reversedIndex];
-      sliderValue.textContent = new Date(timestamp * 1000).toLocaleString();  // Convert to human-readable format
-      timestampImage.src = `/static/${timestamp}.webp`;
+      sliderValue.textContent = new Date(timestamp * 1000).toLocaleString();
+      updateImages(timestamp);
     });
 
-    // Initialize the slider with a default value
+    // Initialize the slider with the most recent timestamp
     slider.value = timestamps.length - 1;
-    sliderValue.textContent = new Date(timestamps[0] * 1000).toLocaleString();  // Convert to human-readable format
-    timestampImage.src = `/static/${timestamps[0]}.webp`;
+    sliderValue.textContent = new Date(timestamps[0] * 1000).toLocaleString();
+    updateImages(timestamps[0]);
   </script>
 {% else %}
   <div class="container">
@@ -130,6 +187,7 @@ def timeline():
 {% endblock %}
 """,
         timestamps=timestamps,
+        timestamp_groups={str(k): v for k, v in timestamp_groups.items()},
     )
 
 
@@ -137,7 +195,7 @@ def timeline():
 def search():
     q = request.args.get("q")
     entries = get_all_entries()
-    embeddings = [np.frombuffer(entry.embedding, dtype=np.float64) for entry in entries]
+    embeddings = [np.frombuffer(entry.embedding, dtype=np.float32) for entry in entries]
     query_embedding = get_embedding(q)
     similarities = [cosine_similarity(query_embedding, emb) for emb in embeddings]
     indices = np.argsort(similarities)[::-1]
@@ -148,20 +206,33 @@ def search():
 {% extends "base_template" %}
 {% block content %}
     <div class="container">
+        <h3 class="mt-3 mb-4">Search Results for "{{ query }}"</h3>
         <div class="row">
             {% for entry in entries %}
                 <div class="col-md-3 mb-4">
                     <div class="card">
                         <a href="#" data-toggle="modal" data-target="#modal-{{ loop.index0 }}">
-                            <img src="/static/{{ entry['timestamp'] }}.webp" alt="Image" class="card-img-top">
+                            <img src="/static/{{ entry.timestamp }}_{{ entry.monitor_id }}.webp" alt="Image" class="card-img-top">
                         </a>
+                        <div class="card-body">
+                            <small class="text-muted">
+                                {{ entry.monitor_name }}<br>
+                                {{ entry.timestamp | timestamp_to_human_readable }}
+                            </small>
+                        </div>
                     </div>
                 </div>
                 <div class="modal fade" id="modal-{{ loop.index0 }}" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
                     <div class="modal-dialog modal-xl" role="document" style="max-width: none; width: 100vw; height: 100vh; padding: 20px;">
                         <div class="modal-content" style="height: calc(100vh - 40px); width: calc(100vw - 40px); padding: 0;">
+                            <div class="modal-header">
+                                <h5 class="modal-title">{{ entry.monitor_name }} - {{ entry.timestamp | timestamp_to_human_readable }}</h5>
+                                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                                    <span aria-hidden="true">&times;</span>
+                                </button>
+                            </div>
                             <div class="modal-body" style="padding: 0;">
-                                <img src="/static/{{ entry['timestamp'] }}.webp" alt="Image" style="width: 100%; height: 100%; object-fit: contain; margin: 0 auto;">
+                                <img src="/static/{{ entry.timestamp }}_{{ entry.monitor_id }}.webp" alt="Image" style="width: 100%; height: 100%; object-fit: contain; margin: 0 auto;">
                             </div>
                         </div>
                     </div>
@@ -172,7 +243,174 @@ def search():
 {% endblock %}
 """,
         entries=sorted_entries,
+        query=q,
     )
+
+
+@app.route("/monitors")
+def monitors():
+    monitors = get_all_monitors()
+    return render_template_string(
+        """
+{% extends "base_template" %}
+{% block content %}
+    <div class="container mt-4">
+        <h2>Monitor Configuration</h2>
+        <p class="text-muted">Select which monitors to capture screenshots from. You can also customize monitor names.</p>
+
+        {% if monitors|length > 0 %}
+        <div class="table-responsive">
+            <table class="table table-striped">
+                <thead>
+                    <tr>
+                        <th>Monitor</th>
+                        <th>Resolution</th>
+                        <th>Name</th>
+                        <th>Enabled</th>
+                        <th>Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for monitor in monitors %}
+                    <tr id="monitor-row-{{ monitor.monitor_index }}">
+                        <td>Monitor {{ monitor.monitor_index }}</td>
+                        <td>{{ monitor.width }} x {{ monitor.height }}</td>
+                        <td>
+                            <span id="name-display-{{ monitor.monitor_index }}">{{ monitor.name }}</span>
+                            <input type="text" class="form-control d-none" id="name-input-{{ monitor.monitor_index }}" value="{{ monitor.name }}">
+                        </td>
+                        <td>
+                            <div class="custom-control custom-switch">
+                                <input type="checkbox" class="custom-control-input" id="enabled-{{ monitor.monitor_index }}"
+                                    {% if monitor.enabled %}checked{% endif %}
+                                    onchange="toggleMonitor({{ monitor.monitor_index }}, this.checked)">
+                                <label class="custom-control-label" for="enabled-{{ monitor.monitor_index }}"></label>
+                            </div>
+                        </td>
+                        <td>
+                            <button class="btn btn-sm btn-primary" id="edit-btn-{{ monitor.monitor_index }}"
+                                onclick="editMonitorName({{ monitor.monitor_index }})">
+                                <i class="bi bi-pencil"></i> Edit
+                            </button>
+                            <button class="btn btn-sm btn-success d-none" id="save-btn-{{ monitor.monitor_index }}"
+                                onclick="saveMonitorName({{ monitor.monitor_index }})">
+                                <i class="bi bi-check"></i> Save
+                            </button>
+                            <button class="btn btn-sm btn-secondary d-none" id="cancel-btn-{{ monitor.monitor_index }}"
+                                onclick="cancelEditMonitorName({{ monitor.monitor_index }}, '{{ monitor.name }}')">
+                                Cancel
+                            </button>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        {% else %}
+        <div class="alert alert-info" role="alert">
+            No monitors detected yet. Monitors will be detected when the screenshot service starts.
+        </div>
+        {% endif %}
+    </div>
+
+    <script>
+        function toggleMonitor(monitorIndex, enabled) {
+            fetch('/api/monitors/' + monitorIndex + '/enabled', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({ enabled: enabled })
+            })
+            .then(response => response.json())
+            .then(data => {
+                if (data.success) {
+                    console.log('Monitor ' + monitorIndex + ' enabled status updated to ' + enabled);
+                } else {
+                    alert('Failed to update monitor status');
+                    // Revert checkbox
+                    document.getElementById('enabled-' + monitorIndex).checked = !enabled;
+                }
+            })
+            .catch(error => {
+                console.error('Error:', error);
+                alert('Error updating monitor status');
+                // Revert checkbox
+                document.getElementById('enabled-' + monitorIndex).checked = !enabled;
+            });
+        }
+
+        function editMonitorName(monitorIndex) {
+            document.getElementById('name-display-' + monitorIndex).classList.add('d-none');
+            document.getElementById('name-input-' + monitorIndex).classList.remove('d-none');
+            document.getElementById('edit-btn-' + monitorIndex).classList.add('d-none');
+            document.getElementById('save-btn-' + monitorIndex).classList.remove('d-none');
+            document.getElementById('cancel-btn-' + monitorIndex).classList.remove('d-none');
+        }
+
+        function cancelEditMonitorName(monitorIndex, originalName) {
+            document.getElementById('name-input-' + monitorIndex).value = originalName;
+            document.getElementById('name-display-' + monitorIndex).classList.remove('d-none');
+            document.getElementById('name-input-' + monitorIndex).classList.add('d-none');
+            document.getElementById('edit-btn-' + monitorIndex).classList.remove('d-none');
+            document.getElementById('save-btn-' + monitorIndex).classList.add('d-none');
+            document.getElementById('cancel-btn-' + monitorIndex).classList.add('d-none');
+        }
+
+        function saveMonitorName(monitorIndex) {
+            const newName = document.getElementById('name-input-' + monitorIndex).value;
+
+            fetch('/api/monitors/' + monitorIndex + '/name', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({ name: newName })
+            })
+            .then(response => response.json())
+            .then(data => {
+                if (data.success) {
+                    document.getElementById('name-display-' + monitorIndex).textContent = newName;
+                    document.getElementById('name-display-' + monitorIndex).classList.remove('d-none');
+                    document.getElementById('name-input-' + monitorIndex).classList.add('d-none');
+                    document.getElementById('edit-btn-' + monitorIndex).classList.remove('d-none');
+                    document.getElementById('save-btn-' + monitorIndex).classList.add('d-none');
+                    document.getElementById('cancel-btn-' + monitorIndex).classList.add('d-none');
+                    // Update cancel button to use new name
+                    document.getElementById('cancel-btn-' + monitorIndex).setAttribute('onclick',
+                        "cancelEditMonitorName(" + monitorIndex + ", '" + newName + "')");
+                } else {
+                    alert('Failed to update monitor name');
+                }
+            })
+            .catch(error => {
+                console.error('Error:', error);
+                alert('Error updating monitor name');
+            });
+        }
+    </script>
+{% endblock %}
+""",
+        monitors=monitors,
+    )
+
+
+@app.route("/api/monitors/<int:monitor_index>/enabled", methods=["POST"])
+def update_monitor_enabled_api(monitor_index):
+    data = request.get_json()
+    enabled = data.get("enabled", False)
+    success = update_monitor_enabled(monitor_index, enabled)
+    return {"success": success}
+
+
+@app.route("/api/monitors/<int:monitor_index>/name", methods=["POST"])
+def update_monitor_name_api(monitor_index):
+    data = request.get_json()
+    name = data.get("name", "")
+    if not name:
+        return {"success": False, "error": "Name cannot be empty"}
+    success = update_monitor_name(monitor_index, name)
+    return {"success": success}
 
 
 @app.route("/static/<filename>")

--- a/openrecall/database.py
+++ b/openrecall/database.py
@@ -6,32 +6,96 @@ from typing import Any, List, Optional, Tuple
 from openrecall.config import db_path
 
 # Define the structure of a database entry using namedtuple
-Entry = namedtuple("Entry", ["id", "app", "title", "text", "timestamp", "embedding"])
+Entry = namedtuple("Entry", ["id", "app", "title", "text", "timestamp", "embedding", "monitor_id", "monitor_name"])
+
+# Define the structure of a monitor configuration entry
+Monitor = namedtuple("Monitor", ["id", "monitor_index", "name", "width", "height", "enabled"])
 
 
 def create_db() -> None:
     """
-    Creates the SQLite database and the 'entries' table if they don't exist.
+    Creates the SQLite database and the 'entries' and 'monitors' tables if they don't exist.
 
     The table schema includes columns for an auto-incrementing ID, application name,
-    window title, extracted text, timestamp, and text embedding.
+    window title, extracted text, timestamp, text embedding, monitor_id, and monitor_name.
+    Also performs schema migration for existing databases.
     """
     try:
         with sqlite3.connect(db_path) as conn:
             cursor = conn.cursor()
+
+            # Create monitors configuration table
             cursor.execute(
-                """CREATE TABLE IF NOT EXISTS entries (
+                """CREATE TABLE IF NOT EXISTS monitors (
                        id INTEGER PRIMARY KEY AUTOINCREMENT,
-                       app TEXT,
-                       title TEXT,
-                       text TEXT,
-                       timestamp INTEGER UNIQUE,
-                       embedding BLOB
+                       monitor_index INTEGER UNIQUE,
+                       name TEXT,
+                       width INTEGER,
+                       height INTEGER,
+                       enabled INTEGER DEFAULT 1
                    )"""
             )
+
+            # Check if entries table exists and needs migration
+            cursor.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='entries'"
+            )
+            table_exists = cursor.fetchone() is not None
+
+            if table_exists:
+                # Check if monitor_id column exists (migration check)
+                cursor.execute("PRAGMA table_info(entries)")
+                columns = [col[1] for col in cursor.fetchall()]
+
+                if 'monitor_id' not in columns:
+                    # Perform migration: add new columns
+                    cursor.execute("ALTER TABLE entries ADD COLUMN monitor_id INTEGER DEFAULT 1")
+                    cursor.execute("ALTER TABLE entries ADD COLUMN monitor_name TEXT DEFAULT 'Primary Monitor'")
+
+                    # Drop the old UNIQUE constraint on timestamp by recreating the table
+                    cursor.execute(
+                        """CREATE TABLE entries_new (
+                               id INTEGER PRIMARY KEY AUTOINCREMENT,
+                               app TEXT,
+                               title TEXT,
+                               text TEXT,
+                               timestamp INTEGER,
+                               embedding BLOB,
+                               monitor_id INTEGER DEFAULT 1,
+                               monitor_name TEXT DEFAULT 'Primary Monitor',
+                               UNIQUE(timestamp, monitor_id)
+                           )"""
+                    )
+                    cursor.execute(
+                        """INSERT INTO entries_new (id, app, title, text, timestamp, embedding, monitor_id, monitor_name)
+                           SELECT id, app, title, text, timestamp, embedding, monitor_id, monitor_name FROM entries"""
+                    )
+                    cursor.execute("DROP TABLE entries")
+                    cursor.execute("ALTER TABLE entries_new RENAME TO entries")
+                    print("Database migrated to support multi-monitor")
+            else:
+                # Create new entries table with multi-monitor support
+                cursor.execute(
+                    """CREATE TABLE IF NOT EXISTS entries (
+                           id INTEGER PRIMARY KEY AUTOINCREMENT,
+                           app TEXT,
+                           title TEXT,
+                           text TEXT,
+                           timestamp INTEGER,
+                           embedding BLOB,
+                           monitor_id INTEGER DEFAULT 1,
+                           monitor_name TEXT DEFAULT 'Primary Monitor',
+                           UNIQUE(timestamp, monitor_id)
+                       )"""
+                )
+
             # Add index on timestamp for faster lookups
             cursor.execute(
                 "CREATE INDEX IF NOT EXISTS idx_timestamp ON entries (timestamp)"
+            )
+            # Add index on monitor_id for filtering
+            cursor.execute(
+                "CREATE INDEX IF NOT EXISTS idx_monitor_id ON entries (monitor_id)"
             )
             conn.commit()
     except sqlite3.Error as e:
@@ -51,7 +115,7 @@ def get_all_entries() -> List[Entry]:
         with sqlite3.connect(db_path) as conn:
             conn.row_factory = sqlite3.Row  # Return rows as dictionary-like objects
             cursor = conn.cursor()
-            cursor.execute("SELECT id, app, title, text, timestamp, embedding FROM entries ORDER BY timestamp DESC")
+            cursor.execute("SELECT id, app, title, text, timestamp, embedding, monitor_id, monitor_name FROM entries ORDER BY timestamp DESC")
             results = cursor.fetchall()
             for row in results:
                 # Deserialize the embedding blob back into a NumPy array
@@ -64,6 +128,8 @@ def get_all_entries() -> List[Entry]:
                         text=row["text"],
                         timestamp=row["timestamp"],
                         embedding=embedding,
+                        monitor_id=row["monitor_id"],
+                        monitor_name=row["monitor_name"],
                     )
                 )
     except sqlite3.Error as e:
@@ -93,7 +159,8 @@ def get_timestamps() -> List[int]:
 
 
 def insert_entry(
-    text: str, timestamp: int, embedding: np.ndarray, app: str, title: str
+    text: str, timestamp: int, embedding: np.ndarray, app: str, title: str,
+    monitor_id: int = 1, monitor_name: str = "Primary Monitor"
 ) -> Optional[int]:
     """
     Inserts a new entry into the database.
@@ -104,6 +171,8 @@ def insert_entry(
         embedding (np.ndarray): The embedding vector for the text.
         app (str): The name of the active application.
         title (str): The title of the active window.
+        monitor_id (int): The monitor index (1-based).
+        monitor_name (str): The friendly name of the monitor.
 
     Returns:
         Optional[int]: The ID of the newly inserted row, or None if insertion fails.
@@ -115,10 +184,10 @@ def insert_entry(
         with sqlite3.connect(db_path) as conn:
             cursor = conn.cursor()
             cursor.execute(
-                """INSERT INTO entries (text, timestamp, embedding, app, title)
-                   VALUES (?, ?, ?, ?, ?)
-                   ON CONFLICT(timestamp) DO NOTHING""", # Avoid duplicates based on timestamp
-                (text, timestamp, embedding_bytes, app, title),
+                """INSERT INTO entries (text, timestamp, embedding, app, title, monitor_id, monitor_name)
+                   VALUES (?, ?, ?, ?, ?, ?, ?)
+                   ON CONFLICT(timestamp, monitor_id) DO NOTHING""", # Avoid duplicates based on timestamp+monitor_id
+                (text, timestamp, embedding_bytes, app, title, monitor_id, monitor_name),
             )
             conn.commit()
             if cursor.rowcount > 0: # Check if insert actually happened
@@ -131,3 +200,150 @@ def insert_entry(
         # More specific error handling can be added (e.g., IntegrityError for UNIQUE constraint)
         print(f"Database error during insertion: {e}")
     return last_row_id
+
+
+def get_all_monitors() -> List[Monitor]:
+    """
+    Retrieves all monitor configurations from the database.
+
+    Returns:
+        List[Monitor]: A list of all monitors as Monitor namedtuples.
+                       Returns an empty list if the table is empty or an error occurs.
+    """
+    monitors: List[Monitor] = []
+    try:
+        with sqlite3.connect(db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            cursor = conn.cursor()
+            cursor.execute("SELECT id, monitor_index, name, width, height, enabled FROM monitors ORDER BY monitor_index")
+            results = cursor.fetchall()
+            for row in results:
+                monitors.append(
+                    Monitor(
+                        id=row["id"],
+                        monitor_index=row["monitor_index"],
+                        name=row["name"],
+                        width=row["width"],
+                        height=row["height"],
+                        enabled=bool(row["enabled"]),
+                    )
+                )
+    except sqlite3.Error as e:
+        print(f"Database error while fetching monitors: {e}")
+    return monitors
+
+
+def upsert_monitor(monitor_index: int, name: str, width: int, height: int, enabled: bool = True) -> Optional[int]:
+    """
+    Inserts or updates a monitor configuration.
+
+    Args:
+        monitor_index (int): The monitor index from mss (1-based).
+        name (str): The friendly name for the monitor.
+        width (int): The width of the monitor in pixels.
+        height (int): The height of the monitor in pixels.
+        enabled (bool): Whether this monitor is enabled for screenshots.
+
+    Returns:
+        Optional[int]: The ID of the inserted/updated row, or None if operation fails.
+    """
+    last_row_id: Optional[int] = None
+    try:
+        with sqlite3.connect(db_path) as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                """INSERT INTO monitors (monitor_index, name, width, height, enabled)
+                   VALUES (?, ?, ?, ?, ?)
+                   ON CONFLICT(monitor_index) DO UPDATE SET
+                       name = excluded.name,
+                       width = excluded.width,
+                       height = excluded.height,
+                       enabled = excluded.enabled""",
+                (monitor_index, name, width, height, int(enabled)),
+            )
+            conn.commit()
+            last_row_id = cursor.lastrowid
+    except sqlite3.Error as e:
+        print(f"Database error during monitor upsert: {e}")
+    return last_row_id
+
+
+def update_monitor_enabled(monitor_index: int, enabled: bool) -> bool:
+    """
+    Updates the enabled status of a monitor.
+
+    Args:
+        monitor_index (int): The monitor index to update.
+        enabled (bool): Whether the monitor should be enabled.
+
+    Returns:
+        bool: True if the update was successful, False otherwise.
+    """
+    try:
+        with sqlite3.connect(db_path) as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "UPDATE monitors SET enabled = ? WHERE monitor_index = ?",
+                (int(enabled), monitor_index),
+            )
+            conn.commit()
+            return cursor.rowcount > 0
+    except sqlite3.Error as e:
+        print(f"Database error during monitor enabled update: {e}")
+        return False
+
+
+def update_monitor_name(monitor_index: int, name: str) -> bool:
+    """
+    Updates the name of a monitor.
+
+    Args:
+        monitor_index (int): The monitor index to update.
+        name (str): The new name for the monitor.
+
+    Returns:
+        bool: True if the update was successful, False otherwise.
+    """
+    try:
+        with sqlite3.connect(db_path) as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "UPDATE monitors SET name = ? WHERE monitor_index = ?",
+                (name, monitor_index),
+            )
+            conn.commit()
+            return cursor.rowcount > 0
+    except sqlite3.Error as e:
+        print(f"Database error during monitor name update: {e}")
+        return False
+
+
+def get_enabled_monitors() -> List[Monitor]:
+    """
+    Retrieves all enabled monitor configurations from the database.
+
+    Returns:
+        List[Monitor]: A list of enabled monitors as Monitor namedtuples.
+                       Returns an empty list if no enabled monitors or an error occurs.
+    """
+    monitors: List[Monitor] = []
+    try:
+        with sqlite3.connect(db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            cursor = conn.cursor()
+            cursor.execute("SELECT id, monitor_index, name, width, height, enabled FROM monitors WHERE enabled = 1 ORDER BY monitor_index")
+            results = cursor.fetchall()
+            for row in results:
+                monitors.append(
+                    Monitor(
+                        id=row["id"],
+                        monitor_index=row["monitor_index"],
+                        name=row["name"],
+                        width=row["width"],
+                        height=row["height"],
+                        enabled=bool(row["enabled"]),
+                    )
+                )
+    except sqlite3.Error as e:
+        print(f"Database error while fetching enabled monitors: {e}")
+    return monitors

--- a/openrecall/screenshot.py
+++ b/openrecall/screenshot.py
@@ -7,7 +7,7 @@ import numpy as np
 from PIL import Image
 
 from openrecall.config import screenshots_path, args
-from openrecall.database import insert_entry
+from openrecall.database import insert_entry, upsert_monitor, get_enabled_monitors
 from openrecall.nlp import get_embedding
 from openrecall.ocr import extract_text_from_image
 from openrecall.utils import (
@@ -67,39 +67,71 @@ def is_similar(
     return similarity >= similarity_threshold
 
 
-def take_screenshots() -> List[np.ndarray]:
-    """Takes screenshots of all connected monitors or just the primary one.
+def enumerate_and_sync_monitors() -> None:
+    """
+    Enumerates all connected monitors and synchronizes them with the database.
 
-    Depending on the `args.primary_monitor_only` flag, captures either
-    all monitors or only the primary monitor (index 1 in mss.monitors).
+    For each detected monitor, creates or updates its entry in the monitors table
+    with current resolution information. New monitors are enabled by default.
+    """
+    with mss.mss() as sct:
+        # sct.monitors[0] is the combined view, skip it
+        # sct.monitors[1:] are individual monitors
+        for i in range(1, len(sct.monitors)):
+            monitor = sct.monitors[i]
+            width = monitor['width']
+            height = monitor['height']
+            name = f"Monitor {i}" if i == 1 else f"Monitor {i}"
+
+            # Upsert the monitor (will preserve enabled status if already exists)
+            upsert_monitor(
+                monitor_index=i,
+                name=name,
+                width=width,
+                height=height,
+                enabled=True  # Default to enabled for new monitors
+            )
+    print(f"Enumerated and synced {len(sct.monitors) - 1} monitors")
+
+
+def take_screenshots() -> List[Tuple[int, str, np.ndarray]]:
+    """Takes screenshots of enabled monitors based on database configuration.
 
     Returns:
-        A list of screenshots, where each screenshot is a NumPy array (RGB).
+        A list of tuples: (monitor_index, monitor_name, screenshot_array)
+        where screenshot_array is a NumPy array (RGB).
     """
-    screenshots: List[np.ndarray] = []
+    screenshots: List[Tuple[int, str, np.ndarray]] = []
+
+    # Get enabled monitors from database
+    enabled_monitors = get_enabled_monitors()
+
+    # If no monitors are configured yet, fall back to all monitors or primary only
+    if not enabled_monitors:
+        print("No monitors configured, using default behavior")
+        with mss.mss() as sct:
+            monitor_indices = [1] if args.primary_monitor_only else range(1, len(sct.monitors))
+
+            for i in monitor_indices:
+                if i < len(sct.monitors):
+                    monitor_info = sct.monitors[i]
+                    sct_img = sct.grab(monitor_info)
+                    screenshot = np.array(sct_img)[:, :, [2, 1, 0]]
+                    screenshots.append((i, f"Monitor {i}", screenshot))
+        return screenshots
+
+    # Take screenshots only from enabled monitors
     with mss.mss() as sct:
-        # sct.monitors[0] is the combined view of all monitors
-        # sct.monitors[1] is the primary monitor
-        # sct.monitors[2:] are other monitors
-        monitor_indices = range(1, len(sct.monitors))  # Skip the 'all monitors' entry
+        for monitor_config in enabled_monitors:
+            monitor_index = monitor_config.monitor_index
 
-        if args.primary_monitor_only:
-            monitor_indices = [1]  # Only index 1 corresponds to the primary monitor
-
-        for i in monitor_indices:
-            # Ensure the index is valid before attempting to grab
-            if i < len(sct.monitors):
-                monitor_info = sct.monitors[i]
-                # Grab the screen
+            if monitor_index < len(sct.monitors):
+                monitor_info = sct.monitors[monitor_index]
                 sct_img = sct.grab(monitor_info)
-                # Convert to numpy array and change BGRA to RGB
                 screenshot = np.array(sct_img)[:, :, [2, 1, 0]]
-                screenshots.append(screenshot)
+                screenshots.append((monitor_index, monitor_config.name, screenshot))
             else:
-                # Handle case where primary_monitor_only is True but only one monitor exists (all monitors view)
-                # This case might need specific handling depending on desired behavior.
-                # For now, we just skip if the index is out of bounds.
-                print(f"Warning: Monitor index {i} out of bounds. Skipping.")
+                print(f"Warning: Monitor {monitor_config.name} (index {monitor_index}) not found. Skipping.")
 
     return screenshots
 
@@ -117,89 +149,66 @@ def record_screenshots_thread() -> None:
     # when used in environments where multiprocessing fork safety is a concern.
     os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
-    last_screenshots: List[np.ndarray] = take_screenshots()
+    # Enumerate and sync monitors on startup
+    enumerate_and_sync_monitors()
+
+    # Initialize last_screenshots with current screenshots
+    # Store as dict: {monitor_index: (monitor_name, screenshot_array)}
+    last_screenshots_dict = {}
+    initial_screenshots = take_screenshots()
+    for monitor_index, monitor_name, screenshot_array in initial_screenshots:
+        last_screenshots_dict[monitor_index] = (monitor_name, screenshot_array)
 
     while True:
         if not is_user_active():
             time.sleep(3)  # Wait longer if user is inactive
             continue
 
-        current_screenshots: List[np.ndarray] = take_screenshots()
+        current_screenshots = take_screenshots()
 
-        # Ensure we have a last_screenshot for each current_screenshot
-        # This handles cases where monitor setup might change (though unlikely mid-run)
-        if len(last_screenshots) != len(current_screenshots):
-             # If monitor count changes, reset last_screenshots and continue
-             last_screenshots = current_screenshots
-             time.sleep(3)
-             continue
+        for monitor_index, monitor_name, current_screenshot in current_screenshots:
+            # Get the last screenshot for this monitor if it exists
+            if monitor_index not in last_screenshots_dict:
+                # New monitor appeared, initialize it
+                last_screenshots_dict[monitor_index] = (monitor_name, current_screenshot)
+                continue
 
+            last_monitor_name, last_screenshot = last_screenshots_dict[monitor_index]
 
-        for i, current_screenshot in enumerate(current_screenshots):
-            last_screenshot = last_screenshots[i]
-
+            # Check if the screenshot has changed significantly
             if not is_similar(current_screenshot, last_screenshot):
-                last_screenshots[i] = current_screenshot  # Update the last screenshot for this monitor
+                # Update the last screenshot for this monitor
+                last_screenshots_dict[monitor_index] = (monitor_name, current_screenshot)
+
+                # Save the screenshot
                 image = Image.fromarray(current_screenshot)
                 timestamp = int(time.time())
-                filename = f"{timestamp}_{i}.webp" # Add monitor index to filename for uniqueness
+                filename = f"{timestamp}_{monitor_index}.webp"
                 filepath = os.path.join(screenshots_path, filename)
                 image.save(
                     filepath,
                     format="webp",
                     lossless=True,
                 )
+
+                # Extract text and create embedding
                 text: str = extract_text_from_image(current_screenshot)
+
                 # Only proceed if OCR actually extracts text
                 if text.strip():
                     embedding: np.ndarray = get_embedding(text)
                     active_app_name: str = get_active_app_name() or "Unknown App"
                     active_window_title: str = get_active_window_title() or "Unknown Title"
+
+                    # Insert entry with monitor information
                     insert_entry(
-                        text, timestamp, embedding, active_app_name, active_window_title, filename # Pass filename
+                        text=text,
+                        timestamp=timestamp,
+                        embedding=embedding,
+                        app=active_app_name,
+                        title=active_window_title,
+                        monitor_id=monitor_index,
+                        monitor_name=monitor_name
                     )
 
-        time.sleep(3) # Wait before taking the next screenshot
-
-    return screenshots
-
-
-def record_screenshots_thread():
-    # TODO: fix the error from huggingface tokenizers
-    import os
-
-    os.environ["TOKENIZERS_PARALLELISM"] = "false"
-
-    last_screenshots = take_screenshots()
-
-    while True:
-        if not is_user_active():
-            time.sleep(3)
-            continue
-
-        screenshots = take_screenshots()
-
-        for i, screenshot in enumerate(screenshots):
-
-            last_screenshot = last_screenshots[i]
-
-            if not is_similar(screenshot, last_screenshot):
-                last_screenshots[i] = screenshot
-                image = Image.fromarray(screenshot)
-                timestamp = int(time.time())
-                image.save(
-                    os.path.join(screenshots_path, f"{timestamp}.webp"),
-                    format="webp",
-                    lossless=True,
-                )
-                text: str = extract_text_from_image(current_screenshot)
-                # Only proceed if OCR actually extracts text
-                if text.strip():
-                    embedding: np.ndarray = get_embedding(text)
-                    active_app_name: str = get_active_app_name() or "Unknown App"
-                    active_window_title: str = get_active_window_title() or "Unknown Title"
-                    insert_entry(
-                        text, timestamp, embedding, active_app_name, active_window_title, filename # Pass filename
-                    )
-
-        time.sleep(3) # Wait before taking the next screenshot
+        time.sleep(3)  # Wait before taking the next screenshot


### PR DESCRIPTION
Implements comprehensive multi-monitor support with a web GUI for configuration:

Database changes:
- Add monitor_id and monitor_name columns to entries table
- Create monitors configuration table for persistent settings
- Update schema with migration support for existing databases
- Add composite unique constraint on (timestamp, monitor_id)

Screenshot module improvements:
- Add monitor enumeration and database synchronization
- Fix duplicate record_screenshots_thread() function definition
- Update screenshot capture to use enabled monitors from config
- Save screenshots with monitor_id in filename (timestamp_monitorid.webp)

Web interface enhancements:
- Add /monitors configuration page with enable/disable toggles
- Allow custom monitor naming through the web UI
- Update timeline view to display all enabled monitors per timestamp
- Update search results to show monitor information
- Add navigation menu with Timeline and Monitors links

All monitor settings persist through application restarts and automatically sync when new monitors are detected.