### PR TITLE
🧹 Remove unused imports from screenshot.py and database.py

### DIFF
--- a/openrecall/database.py
+++ b/openrecall/database.py
@@ -1,7 +1,7 @@
 import sqlite3
 from collections import namedtuple
 import numpy as np
-from typing import Any, List, Optional, Tuple
+from typing import List, Optional
 
 from openrecall.config import db_path
 

--- a/openrecall/screenshot.py
+++ b/openrecall/screenshot.py
@@ -1,6 +1,6 @@
 import os
 import time
-from typing import List, Tuple
+from typing import List
 
 import mss
 import numpy as np


### PR DESCRIPTION
- Removed unused `Tuple` import from `openrecall/screenshot.py`
- Removed unused `Any` and `Tuple` imports from `openrecall/database.py`

This improves code maintainability and readability by cleaning up dead code.